### PR TITLE
feat: Update enricher configuration page controls to selector

### DIFF
--- a/docs/4.0.2-release-notes.md
+++ b/docs/4.0.2-release-notes.md
@@ -1,4 +1,5 @@
 # Features
 - Display help text on the Enricher Configuration page
+- Enhanced the controls to support selecting accepted entity types and vocabulary keys from dropdown
 
 # Fix

--- a/src/ExternalSearch.Providers.Gleif/Constants.cs
+++ b/src/ExternalSearch.Providers.Gleif/Constants.cs
@@ -7,6 +7,13 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
 {
     public static class Constants
     {
+        public struct KeyName
+        {
+            public const string AcceptedEntityType = "acceptedEntityType";
+            public const string LeiVocabularyKey = "leiVocabularyKey";
+            public const string SkipEntityCodeCreation = "skipEntityCodeCreation";
+        }
+
         public const string ComponentName = "Gleif";
         public const string ProviderName = "Gleif";
         public static readonly Guid ProviderId = Guid.Parse("6d47d335-2bf3-4249-88c4-0f08d322c24c");
@@ -46,17 +53,17 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
                 new()
                 {
                     DisplayName = "Accepted Entity Type",
-                    Type = "input",
+                    Type = "entityTypeSelector",
                     IsRequired = true,
-                    Name = nameof(GleifExternalSearchJobData.AcceptedEntityType),
+                    Name = KeyName.AcceptedEntityType,
                     Help = "The entity type that defines the golden records you want to enrich (e.g., /Organization)."
                 },
                 new()
                 {
                     DisplayName = "Lei Code Vocabulary Key",
-                    Type = "input",
+                    Type = "vocabularyKeySelector",
                     IsRequired = false,
-                    Name = nameof(GleifExternalSearchJobData.LeiVocabularyKey),
+                    Name = KeyName.LeiVocabularyKey,
                     Help = "The vocabulary key that contains the LEI codes of companies you want to enrich (e.g., organization.leicodes)."
                 },
                 new()
@@ -64,7 +71,7 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
                     DisplayName = "Skip Entity Code Creation (LEI Code)",
                     Type = "checkbox",
                     IsRequired = false,
-                    Name =  nameof(GleifExternalSearchJobData.SkipEntityCodeCreation),
+                    Name =  KeyName.SkipEntityCodeCreation,
                     Help = "Toggle to control the creation of new entity codes using the LEI code."
                 }
             }

--- a/src/ExternalSearch.Providers.Gleif/GleifExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.Gleif/GleifExternalSearchJobData.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using CluedIn.Core.Crawling;
+using static CluedIn.ExternalSearch.Providers.Gleif.Constants;
 
 namespace CluedIn.ExternalSearch.Providers.Gleif
 {
@@ -7,17 +8,17 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
     {
         public GleifExternalSearchJobData(IDictionary<string, object> configuration)
         {
-            AcceptedEntityType = GetValue(configuration, nameof(AcceptedEntityType), default(string));
-            LeiVocabularyKey = GetValue(configuration, nameof(LeiVocabularyKey), default(string));
-            SkipEntityCodeCreation = GetValue(configuration, nameof(SkipEntityCodeCreation), default(bool));
+            AcceptedEntityType = GetValue(configuration, KeyName.AcceptedEntityType, default(string));
+            LeiVocabularyKey = GetValue(configuration, KeyName.LeiVocabularyKey, default(string));
+            SkipEntityCodeCreation = GetValue(configuration, KeyName.SkipEntityCodeCreation, default(bool));
         }
 
         public IDictionary<string, object> ToDictionary()
         {
             return new Dictionary<string, object> {
-                { nameof(AcceptedEntityType), AcceptedEntityType },
-                { nameof(LeiVocabularyKey), LeiVocabularyKey },
-                { nameof(SkipEntityCodeCreation), SkipEntityCodeCreation },
+                { KeyName.AcceptedEntityType, AcceptedEntityType },
+                { KeyName.LeiVocabularyKey, LeiVocabularyKey },
+                { KeyName.SkipEntityCodeCreation, SkipEntityCodeCreation },
             };
         }
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#42371](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/42371)

After updating the controls (Accepted Entity Types and Vocabulary Keys):
![image](https://github.com/user-attachments/assets/8b32497d-cbc2-4492-bb78-badf4c8c3f1e)
![image](https://github.com/user-attachments/assets/dc485132-e3e0-4637-997b-ecf2aec1631a)

## How has it been tested? <!-- Remove if not needed -->
Manually in local

