### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,3 +3,4 @@
 - Terminology changes
 
 # Fix
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.Gleif/Constants.cs
+++ b/src/ExternalSearch.Providers.Gleif/Constants.cs
@@ -11,7 +11,6 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         {
             public const string AcceptedEntityType = "acceptedEntityType";
             public const string LeiVocabularyKey = "leiVocabularyKey";
-            public const string SkipEntityCodeCreation = "skipEntityCodeCreation";
         }
 
         public const string ComponentName = "Gleif";
@@ -71,14 +70,6 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
                     Name = KeyName.LeiVocabularyKey,
                     Help = "The vocabulary key that contains the LEI codes of companies you want to enrich (e.g., organization.leicodes)."
                 },
-                new()
-                {
-                    DisplayName = $"Skip {EntityCodeLabel} Creation (LEI Code)",
-                    Type = "checkbox",
-                    IsRequired = false,
-                    Name =  KeyName.SkipEntityCodeCreation,
-                    Help = $"Toggle to control the creation of new {EntityCodesLabel.ToLower()} using the LEI code."
-                }
             }
         };
 

--- a/src/ExternalSearch.Providers.Gleif/GleifExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.Gleif/GleifExternalSearchJobData.cs
@@ -10,7 +10,6 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         {
             AcceptedEntityType = GetValue(configuration, KeyName.AcceptedEntityType, default(string));
             LeiVocabularyKey = GetValue(configuration, KeyName.LeiVocabularyKey, default(string));
-            SkipEntityCodeCreation = GetValue(configuration, KeyName.SkipEntityCodeCreation, default(bool));
         }
 
         public IDictionary<string, object> ToDictionary()
@@ -18,12 +17,10 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
             return new Dictionary<string, object> {
                 { KeyName.AcceptedEntityType, AcceptedEntityType },
                 { KeyName.LeiVocabularyKey, LeiVocabularyKey },
-                { KeyName.SkipEntityCodeCreation, SkipEntityCodeCreation },
             };
         }
 
         public string AcceptedEntityType { get; set; }
         public string LeiVocabularyKey { get; set; }
-        public bool SkipEntityCodeCreation { get; set; }
     }
 }

--- a/src/ExternalSearch.Providers.Gleif/GleifExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Gleif/GleifExternalSearchProvider.cs
@@ -129,10 +129,10 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         public IEnumerable<Clue> BuildClues(ExecutionContext context, IExternalSearchQuery query, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)
         {
             var resultItem = result.As<GleifResponse>();
+            var code = new EntityCode(request.EntityMetaData.EntityType, "gleif", resultItem.Data.Data.First()?.Attributes.Lei);
+            var clue = new Clue(code, context.Organization);
 
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
-
-            PopulateMetadata(clue.Data.EntityData, resultItem, request, config);
+            PopulateMetadata(clue.Data.EntityData, resultItem, request);
 
             return new[] { clue };
         }
@@ -141,7 +141,7 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         public IEntityMetadata GetPrimaryEntityMetadata(ExecutionContext context, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)
         {
             var resultItem = result.As<GleifResponse>();
-            return CreateMetadata(resultItem, request, config);
+            return CreateMetadata(resultItem, request);
         }
 
         /// <inheritdoc/>
@@ -196,11 +196,11 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         /// <summary>Creates the metadata.</summary>
         /// <param name="resultItem">The result item.</param>
         /// <returns>The metadata.</returns>
-        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<GleifResponse> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
+        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<GleifResponse> resultItem, IExternalSearchRequest request)
         {
             var metadata = new EntityMetadataPart();
 
-            PopulateMetadata(metadata, resultItem, request, config);
+            PopulateMetadata(metadata, resultItem, request);
 
             return metadata;
         }
@@ -224,21 +224,15 @@ namespace CluedIn.ExternalSearch.Providers.Gleif
         /// <summary>Populates the metadata.</summary>
         /// <param name="metadata">The metadata.</param>
         /// <param name="resultItem">The result item.</param>
-        private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<GleifResponse> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
+        private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<GleifResponse> resultItem, IExternalSearchRequest request)
         {
             var data = resultItem.Data.Data.First();
-
-            var jobData = new GleifExternalSearchJobData(config);
-            var code = request.EntityMetaData.OriginEntityCode;
+            var code = new EntityCode(request.EntityMetaData.EntityType, "gleif", data.Attributes.Lei);
 
             metadata.EntityType       = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name; //data.Attributes.Entity.LegalName?.Name;
             metadata.OriginEntityCode = code;
-
-            if (!jobData.SkipEntityCodeCreation)
-            {
-                metadata.Codes.Add(GetOriginEntityCode(data.Attributes.Lei, request));
-            }
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             if (data.Attributes.Entity.OtherNames != null)
                 metadata.Aliases.AddRange(data.Attributes.Entity?.OtherNames.Select(v => v.Name));


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Gleif data, but the one from other enricher turn into no source
![image](https://github.com/user-attachments/assets/3513c6a0-2160-4781-980d-c98c31b1548a)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
